### PR TITLE
feat/qb-2301: Add apis for coingecko/marketcap

### DIFF
--- a/apps/web-stratos/src/pages/api/circulating-supply.tsx
+++ b/apps/web-stratos/src/pages/api/circulating-supply.tsx
@@ -1,0 +1,16 @@
+import { getMetrics } from '@/screens/home/components/tokenomics/queries';
+import { bigToNativeDecimals } from '@/screens/home/components/tokenomics/utils';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+type MetricsData = {
+  circulation_supply: string;
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<string>) {
+  try {
+    const result: MetricsData = await getMetrics();
+    res.status(200).send(bigToNativeDecimals(result.circulation_supply));
+  } catch (err) {
+    res.status(400).json({ error: 'failed to load data' });
+  }
+}

--- a/apps/web-stratos/src/pages/api/total-supply.tsx
+++ b/apps/web-stratos/src/pages/api/total-supply.tsx
@@ -1,0 +1,16 @@
+import { getMetrics } from '@/screens/home/components/tokenomics/queries';
+import { bigToNativeDecimals } from '@/screens/home/components/tokenomics/utils';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+type MetricsData = {
+  total_supply: string;
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<string>) {
+  try {
+    const result: MetricsData = await getMetrics();
+    res.status(200).send(bigToNativeDecimals(result.total_supply));
+  } catch (err) {
+    res.status(400).json({ error: 'failed to load data' });
+  }
+}

--- a/apps/web-stratos/src/screens/home/components/charts/TokenomicChart.tsx
+++ b/apps/web-stratos/src/screens/home/components/charts/TokenomicChart.tsx
@@ -1,7 +1,5 @@
 import { useId, FC } from 'react';
 
-import { BigNumber } from 'ethers';
-
 import { Tooltip, BarChart, CartesianGrid, XAxis, YAxis, Bar } from 'recharts';
 
 interface ITokenomicChart {

--- a/apps/web-stratos/src/screens/home/components/tokenomics/index.tsx
+++ b/apps/web-stratos/src/screens/home/components/tokenomics/index.tsx
@@ -1,5 +1,4 @@
 import { FC } from 'react';
-import numeral from 'numeral';
 import dynamic from 'next/dynamic';
 
 import chainConfig from '@/chainConfig';

--- a/apps/web-stratos/src/screens/home/components/tokenomics/utils.ts
+++ b/apps/web-stratos/src/screens/home/components/tokenomics/utils.ts
@@ -1,6 +1,11 @@
-import { BigNumberish } from 'ethers';
+import { BigNumberish, FixedNumber } from 'ethers';
 import { formatUnits } from 'ethers/lib/utils';
 
 export function prettyFormat(value: BigNumberish, unitName?: number, points = 8): number {
   return +(+formatUnits(value, unitName)).toFixed(points);
 }
+
+export const bigToNativeDecimals = (bn: string, decimals?: number): string =>
+  FixedNumber.fromString(bn)
+    .divUnsafe(FixedNumber.from((10 ** (decimals || 18)).toString()))
+    .toString();


### PR DESCRIPTION
Two new apis:
```
http://localhost:13000/stratos/api/total-supply
```
```
http://localhost:13000/stratos/api/circulating-supply
```
<img width="481" alt="Screenshot 2023-11-16 at 17 56 22" src="https://github.com/stratosnet/big-dipper-2.0-cosmos/assets/121880388/1284f494-c86f-4877-ad35-58e352f18486">
<img width="545" alt="Screenshot 2023-11-16 at 17 56 25" src="https://github.com/stratosnet/big-dipper-2.0-cosmos/assets/121880388/b35791cf-addb-4d12-aefa-efc860e82d20">
